### PR TITLE
Expose focal point parse logic

### DIFF
--- a/PictureHelper.cs
+++ b/PictureHelper.cs
@@ -1,13 +1,14 @@
-﻿using EPiServer;
+﻿using System.Diagnostics.CodeAnalysis;
+using EPiServer;
 using EPiServer.Core;
 using EPiServer.ServiceLocation;
 using EPiServer.Web.Routing;
 using Microsoft.AspNetCore.Html;
 using Microsoft.AspNetCore.Mvc.Rendering;
-using System.Globalization;
 
 namespace PictureRenderer.Optimizely
 {
+    [SuppressMessage("ReSharper", "MemberCanBePrivate.Global")]
     public static class PictureHelper
     {
         public static HtmlString Picture(this IHtmlHelper helper, ContentReference imageReference, PictureProfile profile, LazyLoading lazyLoading)
@@ -15,6 +16,7 @@ namespace PictureRenderer.Optimizely
             return Picture(helper, imageReference, profile, string.Empty, lazyLoading);
         }
 
+        [SuppressMessage("ReSharper", "UnusedParameter.Global")]
         public static HtmlString Picture(this IHtmlHelper helper, ContentReference imageReference, PictureProfile profile, string altText = "", LazyLoading lazyLoading = LazyLoading.Browser)
         {
             if (imageReference == null)
@@ -35,17 +37,8 @@ namespace PictureRenderer.Optimizely
                 if (image?.Property["ImageFocalPoint"]?.Value != null)
                 {
                     var focalPointString = image.Property["ImageFocalPoint"].ToString();
-
-                    //get focal point in format x|y (ImagePointEditor format)
-                    var focalValues = focalPointString.Split('|');
-                    if (focalValues.Length == 2)
-                    {
-                        if (!(double.TryParse(focalValues[0], NumberStyles.Any, CultureInfo.InvariantCulture, out focalPoint.x) && (double.TryParse(focalValues[1], NumberStyles.Any, CultureInfo.InvariantCulture, out focalPoint.y))))
-                        {
-                            //not able to parse the values
-                            focalPoint = default;
-                        }
-                    }
+                    
+                    focalPoint = focalPointString.ParseFocalPoint();
                 }
             }
 

--- a/StringExtensions.cs
+++ b/StringExtensions.cs
@@ -1,0 +1,25 @@
+﻿using System.Globalization;
+
+namespace PictureRenderer.Optimizely
+{
+    public static class StringExtensions
+    {
+        public static (double x, double y) ParseFocalPoint(this string focalPointString)
+        {
+            if (focalPointString == default)
+                return default;
+            
+            (double x, double y) focalPoint = default;
+            var focalValues = focalPointString.Split('|');
+
+            if (focalValues.Length != 2)
+                return focalPoint;
+
+            if (!(double.TryParse(focalValues[0], NumberStyles.Any, CultureInfo.InvariantCulture, out focalPoint.x) &&
+                  double.TryParse(focalValues[1], NumberStyles.Any, CultureInfo.InvariantCulture, out focalPoint.y)))
+                focalPoint = default;
+
+            return focalPoint;
+        }
+    }
+}


### PR DESCRIPTION
Hello, 

Here's a suggestion PR. It exposes the parse logic for the focal points in a way developers can reuse elsewhere in their own code. We're currently simply copying the logic in our code for the moment. 

Thank you, 
David